### PR TITLE
Avoid `clippy::equatable_if_let`

### DIFF
--- a/src/macros/concat_assert.rs
+++ b/src/macros/concat_assert.rs
@@ -115,9 +115,10 @@ macro_rules! concat_assert {
     ($condition:expr $(,)?) => {
         $crate::__::assert!($condition);
     };
-    ($condition:expr, $($fmt:tt)*) => {
+    ($condition:expr, $($fmt:tt)*) => {{
+        #[allow(clippy::equatable_if_let)]
         if let false = $condition {
             $crate::concat_panic!{$($fmt)*}
         }
-    };
+    }};
 }


### PR DESCRIPTION
I'm not sure why there was a `let` to begin with, I hope this wasn't a workaround for something.
This "fix" would avoid triggering a false-positive of `clippy::equatable_if_let`.

See https://github.com/rust-lang/rust-clippy/issues/9066.