### PR TITLE
Bumped version to 0.2.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_panic"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2021"
 license = "Zlib"
@@ -19,8 +19,8 @@ include = [
 
 [workspace]
 
-[dependencies.konst_kernel]
-version = "0.3"
+[dependencies.typewit]
+version = "1.1.0"
 optional = true
 
 [dependencies.const_panic_proc_macros]
@@ -40,7 +40,7 @@ features = ["small_rng"]
 default = ["non_basic"]
 
 rust_1_64 = []
-non_basic = ["konst_kernel"]
+non_basic = ["typewit"]
 docsrs = []
 derive = ["const_panic_proc_macros", "non_basic"]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,8 +12,6 @@ Made `ArrayString::as_bytes` take constant time when the `"rust_1_64"` feature i
 
 Made `"derive"` feature enable `"non_basic"` feature.
 
-Added `konst_kernel = 0.3` dependency, enabled by `"non_basic"` feature.
-
 ### 0.2.5
 
 Added `"rust_1_64"` feature, which enables formatting impls which require newer versions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ mod reexported_non_basic {
         primitive::str,
     };
 
-    pub use konst_kernel::type_eq::MakeTypeWitness;
+    pub use typewit::MakeTypeWitness;
 
     pub use crate::{
         concat_panic_::{compute_length, make_panic_string_unwrapped},

--- a/src/macros/concat_macro.rs
+++ b/src/macros/concat_macro.rs
@@ -1,6 +1,6 @@
 use crate::ArrayString;
 
-use konst_kernel::type_eq::{MakeTypeWitness, TypeEq, TypeWitnessTypeArg};
+use typewit::{MakeTypeWitness, TypeEq, TypeWitnessTypeArg};
 
 /// Concatenates [`PanicFmt`] constants into a `&'static str`
 ///


### PR DESCRIPTION
Replaced `konst_kernel` dependency with `typewit = "1.1"`