### PR TITLE
Create a slice of appropriate size so that nuls aren't logged

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -1,4 +1,7 @@
-use crate::{utils::RangedBytes, FmtArg, PanicFmt, PanicVal};
+use crate::{
+    utils::{bytes_up_to, RangedBytes},
+    FmtArg, PanicFmt, PanicVal,
+};
 
 use core::{
     cmp::PartialEq,
@@ -287,36 +290,4 @@ impl<const CAP: usize> TinyString<CAP> {
             bytes: &self.buffer,
         }
     }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-#[cfg(not(feature = "rust_1_64"))]
-const fn bytes_up_to(buffer: &[u8], upto: usize) -> &[u8] {
-    let mut to_truncate = buffer.len() - upto;
-    let mut out: &[u8] = buffer;
-
-    while to_truncate != 0 {
-        if let [rem @ .., _] = out {
-            out = rem;
-        }
-        to_truncate -= 1;
-    }
-
-    if out.len() != upto {
-        panic!("BUG!")
-    }
-
-    out
-}
-
-#[cfg(feature = "rust_1_64")]
-const fn bytes_up_to(buffer: &[u8], upto: usize) -> &[u8] {
-    if upto > buffer.len() {
-        return buffer;
-    }
-
-    // SAFETY: the above conditional ensures that `upto` doesn't
-    // create a partially-dangling slice
-    unsafe { core::slice::from_raw_parts(buffer.as_ptr(), upto) }
 }

--- a/src/concat_panic_.rs
+++ b/src/concat_panic_.rs
@@ -1,7 +1,7 @@
 use crate::{
     fmt::FmtKind,
     panic_val::{PanicClass, PanicVal, StrFmt},
-    utils::{string_cap, WasTruncated},
+    utils::{bytes_up_to, string_cap, WasTruncated},
 };
 
 /// Panics by concatenating the argument slice.
@@ -258,7 +258,8 @@ const fn panic_inner<const LEN: usize>(args: &[&[PanicVal<'_>]]) -> Result<Never
     }
 
     unsafe {
-        let str = core::str::from_utf8_unchecked(&buffer);
+        let buffer = bytes_up_to(&buffer, len);
+        let str = core::str::from_utf8_unchecked(buffer);
         panic!("{}", str)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -228,3 +228,35 @@ pub(crate) const fn tail_byte_array<const TO: usize>(
         bytes,
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(not(feature = "rust_1_64"))]
+pub const fn bytes_up_to(buffer: &[u8], upto: usize) -> &[u8] {
+    let mut to_truncate = buffer.len() - upto;
+    let mut out: &[u8] = buffer;
+
+    while to_truncate != 0 {
+        if let [rem @ .., _] = out {
+            out = rem;
+        }
+        to_truncate -= 1;
+    }
+
+    if out.len() != upto {
+        panic!("BUG!")
+    }
+
+    out
+}
+
+#[cfg(feature = "rust_1_64")]
+pub const fn bytes_up_to(buffer: &[u8], upto: usize) -> &[u8] {
+    if upto > buffer.len() {
+        return buffer;
+    }
+
+    // SAFETY: the above conditional ensures that `upto` doesn't
+    // create a partially-dangling slice
+    unsafe { core::slice::from_raw_parts(buffer.as_ptr(), upto) }
+}


### PR DESCRIPTION
After an upgrade to `1.83.0-nightly (0ee7cb5e3 2024-09-10)`, rustc starts logging all of the `nul` bytes in the string buffer during a compile-time panic. This can be resolved by resizing the buffer slice before panicking.