### PR TITLE
Add concat_panic_truncate function and macro, to allow panics with a configurable max upper bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ mod fmt_impls {
 }
 
 pub use crate::{
-    concat_panic_::{concat_panic, MAX_PANIC_MSG_LEN},
+    concat_panic_::{concat_panic, concat_panic_truncate, MAX_PANIC_MSG_LEN},
     panic_val::PanicVal,
     wrapper::StdWrapper,
 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -364,6 +364,21 @@ macro_rules! concat_panic {
     )
 }
 
+/// Panics with the concanenation of the arguments, truncating after the max
+/// length passed as the first argument to the macro.
+///
+/// See [`concat_panic`] for more details.
+#[macro_export]
+macro_rules! concat_panic_truncate {
+    ($max_len:expr, $($args:tt)*) => (
+        $crate::__concat_func_setup!{
+            (|args| $crate::concat_panic_truncate::<$max_len>(args))
+            []
+            [$($args)*,]
+        }
+    )
+}
+
 // This macro takes the optional `$fmt:expr;` argument before everything else.
 // But I had to parse the argument manually,
 // because `$fmt:expr;` fails compilation instead of trying the following branches


### PR DESCRIPTION
I'm looking to use `const_panic` in an embedded system with little RAM. It's mostly used from const contexts, but it would be useful to be able to configure smaller max stack usage for potential run-time scenarios too.

This change would allow a caller to configure a max panic message length for a particular panic. Because Rust doesn't allow math on a generic constant, it doesn't have the logic of starting with a smaller buffer and progressively growing up to the max.

An alternative to this approach might be to make `MAX_PANIC_MSG_LEN` itself configurable based on a cargo feature, maybe `small_stack` to set some max like `64` or a series of `max_panic_msg_len_32`/`max_panic_msg_len_64`/`max_panic_msg_len_128`/etc features, though mutually exclusive features are generally discouraged by Cargo.

Do you have any thoughts on how you'd prefer this to be done? I'd be glad to take another pass at a solution if you prefer something like the cargo feature, or something else.